### PR TITLE
implement CPU uniform

### DIFF
--- a/source/dopt/core/cpu/package.d
+++ b/source/dopt/core/cpu/package.d
@@ -13,9 +13,11 @@ void initialize()
 {
     import dopt.core.cpu.basic;
     import dopt.core.cpu.math;
+    import dopt.core.cpu.random;
 
     dopt.core.cpu.basic.initialize();
     dopt.core.cpu.math.initialize();
+    dopt.core.cpu.random.initialize();
 }
 
 /**

--- a/source/dopt/core/cpu/random.d
+++ b/source/dopt/core/cpu/random.d
@@ -16,10 +16,10 @@ private
 {
     void uniform(Operation op, const(Buffer)[] inputs, Buffer output)
     {
-        import std.random : uniform;
+        import std.random : uniform01;
 
-        ubyte[] arr = output.as!ubyte[0 .. op.volume];
+        float[] arr = output.as!float[0 .. op.volume];
         foreach (ref v; arr)
-            v = uniform!ubyte;
+            v = uniform01!float + float.epsilon; // by default CUDA's random is 0-1 including 1 but not zero, D is 0-1 including 0 but not one.
     }
 }

--- a/source/dopt/core/cpu/random.d
+++ b/source/dopt/core/cpu/random.d
@@ -1,0 +1,25 @@
+module dopt.core.cpu.random;
+
+import dopt.core;
+
+package
+{
+    void initialize()
+    {
+        import std.functional : toDelegate;
+
+        registerCPUKernel("uniform", new CPUKernelDelegate(toDelegate(&uniform)));
+    }
+}
+
+private
+{
+    void uniform(Operation op, const(Buffer)[] inputs, Buffer output)
+    {
+        import std.random : uniform;
+
+        ubyte[] arr = output.as!ubyte[0 .. op.volume];
+        foreach (ref v; arr)
+            v = uniform!ubyte;
+    }
+}


### PR DESCRIPTION
before implementing more kernels I have a few questions about the current design:

why the `initialize` function instead of `shared static this`?

currently not all unittests are passing for me (not implemented CPU stuff and my GPU not being nvidia), should we add a check to CUDA unittests if CUDA is supported and implement the CPU stuff before doing the other stuff?

The OpDef stuff looks useful for testing, is it used for CPU kernels yet? I implemented the uniform function first thinking it was a ubyte[] instead of float[] but no additional test failed. I'm not sure if I used the Buffer correctly either as I don't quite understand where it comes from yet.